### PR TITLE
add discord link instead of telegram

### DIFF
--- a/components/Menu/index.js
+++ b/components/Menu/index.js
@@ -124,10 +124,10 @@ export default function Menu() {
 							Github
 						</MenuItemInner>
           </MenuItem>
-          <MenuItem id="link" href="https://t.me/vexchange">
+          <MenuItem id="link" href="https://discord.gg/krPDhtcumr">
 						<MenuItemInner>
 							<MessageCircle size={14} />
-							Telegram
+							Discord
 						</MenuItemInner>
           </MenuItem>
         </MenuFlyout>


### PR DESCRIPTION
# Why?
We've moved off Telegram

# What Changed?
Link

# Example
<img width="267" alt="CleanShot 2021-11-30 at 16 03 05@2x" src="https://user-images.githubusercontent.com/1138619/144127677-5217ecc4-d498-430a-8f70-a74c20337ff9.png">
