### PR TITLE
Feature/tokens whitelist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@utils/*": ["./utils/*"],
+      "@state/*": ["./state/*"],
+      "@components/*": ["./components/*"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "rebass": "^4.0.7",
         "styled-components": "^5.3.0",
         "thorify": "^1.5.5",
+        "unstated-next": "1.1.0",
         "vexchange-sdk": "^1.0.3",
         "wcag-contrast": "^3.0.0",
         "web3": "^1.4.0"
@@ -8469,6 +8470,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unstated-next": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unstated-next/-/unstated-next-1.1.0.tgz",
+      "integrity": "sha512-AAn47ZncPvgBGOvMcn8tSRxsrqwf2VdAPxLASTuLJvZt4rhKfDvUkmYZLGfclImSfTVMv7tF4ynaVxin0JjDCA=="
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "license": "BSD-2-Clause",
@@ -14808,6 +14814,11 @@
     },
     "unpipe": {
       "version": "1.0.0"
+    },
+    "unstated-next": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unstated-next/-/unstated-next-1.1.0.tgz",
+      "integrity": "sha512-AAn47ZncPvgBGOvMcn8tSRxsrqwf2VdAPxLASTuLJvZt4rhKfDvUkmYZLGfclImSfTVMv7tF4ynaVxin0JjDCA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "rebass": "^4.0.7",
     "styled-components": "^5.3.0",
     "thorify": "^1.5.5",
+    "unstated-next": "1.1.0",
     "vexchange-sdk": "^1.0.3",
     "wcag-contrast": "^3.0.0",
     "web3": "^1.4.0"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import { StateProvider } from "@state/index";
 import { globalStyles } from '../shared/styles'
 import styled from '@emotion/styled'
 
@@ -35,7 +36,9 @@ const App = ({ Component, pageProps }) => (
   <>
     <AppWrapper>
       <BodyWrapper>
-        <Component {...pageProps} />
+        <StateProvider>
+            <Component {...pageProps} />
+        </StateProvider>
       </BodyWrapper>
     </AppWrapper>
     { globalStyles }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -13,7 +13,7 @@ class MyDocument extends Document {
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
           <link href="https://fonts.googleapis.com/css2?family=Satisfy&display=swap" rel="stylesheet" />
 
-          <script async src="https://www.googletagmanager.com/gtag/js?id=G-YEP0Q1NNQ3"></script>
+          <script async src="https://www.googletagmanager.com/gtag/js?id=G-YEP0Q1NNQ3" />
           <script
             dangerouslySetInnerHTML={{__html: `
               window.dataLayer = window.dataLayer || [];

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import Big from "big.js";
 import Head from "next/head";
 import axios from "axios";
-import CoinGecko from "coingecko-api";
 import styled from "@emotion/styled";
 import Image from "next/image";
 import { Flex, Box, Text } from "rebass";
@@ -14,7 +13,7 @@ import Header from "../components/Header";
 import PairTable from "../components/PairTable";
 import TokenTable from "../components/TokenTable";
 import Card from "../components/Card";
-import { API_BASE_URL } from "../utils/constants/vexchange";
+import { API_BASE_URL } from "@utils/constants/vexchange";
 
 const LargeText = styled.p`
   font-size: 32px;
@@ -127,7 +126,7 @@ export default function Home() {
         <link
           rel="icon"
           href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔥</text></svg>"
-        ></link>
+        />
       </Head>
       <HeaderWrapper>
         <Header />

--- a/pages/index.js
+++ b/pages/index.js
@@ -72,7 +72,7 @@ export default function Home() {
     const getPairs = async () => {
       const pairsApiResult = await axios(`${API_BASE_URL}pairs`);
       const filtered = Object.values(pairsApiResult.data).filter(pair =>
-          pair.token0.contractAddress in whiteListedTokens && pair.token1.contractAddress in whiteListedTokens
+          whiteListedTokens.has(pair.token0.contractAddress) && whiteListedTokens.has(pair.token1.contractAddress)
       );
       const _pairs = filtered.map((e) => {
         e.totalReserveUsd =
@@ -97,7 +97,7 @@ export default function Home() {
     const getTokens = async () => {
       const tokensApiResult = await axios(`${API_BASE_URL}tokens`);
       const _tokens = Object.values(tokensApiResult.data);
-      const filtered = _tokens.filter(token => token.contractAddress in whiteListedTokens);
+      const filtered = _tokens.filter(token => whiteListedTokens.has(token.contractAddress));
 
       setTokens(filtered);
     }

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,7 @@ import styled from "@emotion/styled";
 import Image from "next/image";
 import { Flex, Box, Text } from "rebass";
 import { keyframes } from "@emotion/react";
-
+import { whitelist } from "@state/whitelist";
 import { formatCurrency } from "../utils";
 import { PageWrapper } from "../shared/styles";
 import Header from "../components/Header";
@@ -65,8 +65,10 @@ export default function Home() {
   const [tokens, setTokens] = useState([]);
   const [tvl, setTVL] = useState(0);
   const [vol, setVol] = useState(0);
+  const { whiteListedTokens } = whitelist.useContainer();
 
   useEffect(() => {
+    if (!whiteListedTokens) return;
     const getPairs = async () => {
       const pairsApiResult = await axios(`${API_BASE_URL}pairs`);
       const _pairs = Object.values(pairsApiResult.data).map((e) => {
@@ -85,17 +87,20 @@ export default function Home() {
       setPairs(_pairs);
     };
     getPairs();
-  }, []);
+  }, [whiteListedTokens]);
 
   useEffect(() => {
+    if (!whiteListedTokens) return;
     const getTokens = async () => {
       const tokensApiResult = await axios(`${API_BASE_URL}tokens`);
       const _tokens = Object.values(tokensApiResult.data);
-      setTokens(_tokens);
+      const filtered = _tokens.filter(token => token.contractAddress in whiteListedTokens);
+
+      setTokens(filtered);
     }
 
     getTokens();
-  }, []);
+  }, [whiteListedTokens]);
 
   useEffect(() => {
     const calculate = () => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -71,7 +71,10 @@ export default function Home() {
     if (!whiteListedTokens) return;
     const getPairs = async () => {
       const pairsApiResult = await axios(`${API_BASE_URL}pairs`);
-      const _pairs = Object.values(pairsApiResult.data).map((e) => {
+      const filtered = Object.values(pairsApiResult.data).filter(pair =>
+          pair.token0.contractAddress in whiteListedTokens && pair.token1.contractAddress in whiteListedTokens
+      );
+      const _pairs = filtered.map((e) => {
         e.totalReserveUsd =
           +e.token0Reserve * e.token0.usdPrice +
           +e.token1Reserve * e.token1.usdPrice;

--- a/pages/index.js
+++ b/pages/index.js
@@ -93,7 +93,7 @@ export default function Home() {
   }, [whiteListedTokens]);
 
   useEffect(() => {
-    if (!whiteListedTokens) return;
+    if (!whiteListedTokens) { return; }
     const getTokens = async () => {
       const tokensApiResult = await axios(`${API_BASE_URL}tokens`);
       const _tokens = Object.values(tokensApiResult.data);

--- a/state/index.js
+++ b/state/index.js
@@ -1,0 +1,11 @@
+// Import state helpers
+import { whitelist } from "@state/whitelist"
+
+// Export state wrapper
+export function StateProvider({ children }) {
+    return (
+        <whitelist.Provider>
+            {children}
+        </whitelist.Provider>
+    );
+}

--- a/state/whitelist.js
+++ b/state/whitelist.js
@@ -1,20 +1,35 @@
 import { createContainer } from "unstated-next";
 import { useEffect, useState } from "react";
+import { getAddress } from "ethers/lib/utils";
 import axios from "axios";
+import { WVET } from "vexchange-sdk";
 
 function useWhitelist() {
+    // Addresses are in checksummed format
     const [whiteListedTokens, setWhitelistedTokens] = useState(null);
-
     const FOUNDATION_WHITELIST_URL = "https://vechain.github.io/token-registry/main.json";
 
-    const fetchWhitelist = async () =>
-    {
-        const result = await axios.get(FOUNDATION_WHITELIST_URL);
-        console.log(result);
-    }
-
     // --> Lifecycle: on mount
-    useEffect(fetchWhitelist, [])
+    useEffect(() => {
+        const fetchWhitelist = async () => {
+            const result = await axios.get(FOUNDATION_WHITELIST_URL);
+            const whitelist = {};
+            result.data.forEach((token) => {
+                // Converts all addresses into checksummed addresses
+                const tokenContractAddress = getAddress(token.address);
+                whitelist[tokenContractAddress] = token;
+            })
+            // Need to include the WVET address manually as it is not in the foundation whitelist
+            whitelist[WVET[1].address] = WVET[1];
+            setWhitelistedTokens(whitelist);
+        }
+
+        fetchWhitelist();
+    }, []);
+
+    return {
+        whiteListedTokens
+    }
 }
 
-export const whitelist = createContainer(useWhitelist)
+export const whitelist = createContainer(useWhitelist);

--- a/state/whitelist.js
+++ b/state/whitelist.js
@@ -13,14 +13,14 @@ function useWhitelist() {
     useEffect(() => {
         const fetchWhitelist = async () => {
             const result = await axios.get(FOUNDATION_WHITELIST_URL);
-            const whitelist = {};
+            const whitelist = new Map();
             result.data.forEach((token) => {
                 // Converts all addresses into checksummed addresses
                 const tokenContractAddress = getAddress(token.address);
-                whitelist[tokenContractAddress] = token;
+                whitelist.set(tokenContractAddress, token);
             })
             // Need to include the WVET address manually as it is not in the foundation whitelist
-            whitelist[WVET[1].address] = WVET[1];
+            whitelist.set(WVET[1].address, WVET[1]);
             setWhitelistedTokens(whitelist);
         }
 

--- a/state/whitelist.js
+++ b/state/whitelist.js
@@ -1,0 +1,20 @@
+import { createContainer } from "unstated-next";
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+function useWhitelist() {
+    const [whiteListedTokens, setWhitelistedTokens] = useState(null);
+
+    const FOUNDATION_WHITELIST_URL = "https://vechain.github.io/token-registry/main.json";
+
+    const fetchWhitelist = async () =>
+    {
+        const result = await axios.get(FOUNDATION_WHITELIST_URL);
+        console.log(result);
+    }
+
+    // --> Lifecycle: on mount
+    useEffect(fetchWhitelist, [])
+}
+
+export const whitelist = createContainer(useWhitelist)


### PR DESCRIPTION
1. In this refactor I am also introducing this "new" state management tool called `unstated-next`, which I got to know and is used in `governance-frontend` 
2. It provides a cleaner, more elegant way to manage state for react/nextjs apps as opposed to using hooks and context 
3. For future refactors of `info`, `farm`, or even `swap`, we should aim to replace the existing hooks/context with `unstated` whenever possible/sensible 